### PR TITLE
Fix for Issue #3. Adding #openOn: message to IRCBasicDisplay, which i…

### DIFF
--- a/Pharo-IRC-GUI.package/IRCBasicDisplay.class/class/exampleFreenode.st
+++ b/Pharo-IRC-GUI.package/IRCBasicDisplay.class/class/exampleFreenode.st
@@ -2,5 +2,4 @@ as yet unclassified
 exampleFreenode
 	| conn |
 	conn := IRCConnection new.
-	(self connection: conn) openWithSpec.
-	conn connect.
+	self openOn: conn.

--- a/Pharo-IRC-GUI.package/IRCBasicDisplay.class/class/openOn..st
+++ b/Pharo-IRC-GUI.package/IRCBasicDisplay.class/class/openOn..st
@@ -1,0 +1,9 @@
+instance creation
+openOn: anIRCConnection
+	"Open a new window on a specified IRCConnection instance"
+	| model |
+	model := self connection: anIRCConnection.
+	model openWithSpec.
+	model window whenClosedDo: [ model windowCloseAction ].
+	anIRCConnection isConnected ifFalse: [ 
+		anIRCConnection connect ].

--- a/Pharo-IRC-GUI.package/IRCBasicDisplay.class/instance/windowCloseAction.st
+++ b/Pharo-IRC-GUI.package/IRCBasicDisplay.class/instance/windowCloseAction.st
@@ -1,0 +1,7 @@
+as yet unclassified
+windowCloseAction
+	"When the model's window is closed, we should
+	terminate any active connection that might be
+	attached to it."
+	self connection ifNotNil: [ 
+		self connection disconnect ].


### PR DESCRIPTION
## What ##
Issue #3 highlighted how closing the underlying window of a Spec-built `IRCBasicDisplay` would leave the underlying `IRCConnection` instance's process running. Not good.
  
## Solution ##
Added `IRCBasicDisplay class >> #openOn:` which handles both the building of the Spec model (see below) and adding the window close action that will attempt to disconnect the underlying connection. All other class level convenience methods have been updated to send this new message.
 
## Caveat ##
It seems that there is no way to add an action for when a Spec `ComposableModel` window will close *before* the model is built with Spec. That would be much more convenient, in particular being able to add this action in `#initializeWidgets` or some similar point in the process.

```smalltalk
| we |
       we := WindowExample new.
       we openWithSpec.
       we window whenClosedDo: [ UIManager default inform: 'Bye bye!' ].
```
  
Instead, the underlying window model must be accessed after the Spec component is built, which means putting more configuration on the users of the class. My solution was simply to hide this extra configuration in class level convenience functions.
  
## Closes ##
#3 