### PR TITLE
SSL and Basic Password for Connections

### DIFF
--- a/Pharo-IRC-Base.package/IRCConnection.class/class/setupIncomingHandlers.st
+++ b/Pharo-IRC-Base.package/IRCConnection.class/class/setupIncomingHandlers.st
@@ -34,4 +34,5 @@ setupIncomingHandlers
 		
 		"RPL_YOUREOPER"
 		'381' -> #processRplYoureOper:.
+
 		 } asDictionary.

--- a/Pharo-IRC-Base.package/IRCConnection.class/instance/connectSecure.st
+++ b/Pharo-IRC-Base.package/IRCConnection.class/instance/connectSecure.st
@@ -1,0 +1,6 @@
+initialization
+connectSecure
+	"Connect using TLS/SSL"
+	self
+		connectSecureToHostNamed: hostname
+		port: port.

--- a/Pharo-IRC-Base.package/IRCConnection.class/instance/connectSecureToHostNamed.port..st
+++ b/Pharo-IRC-Base.package/IRCConnection.class/instance/connectSecureToHostNamed.port..st
@@ -1,0 +1,12 @@
+initialization
+connectSecureToHostNamed: aHostname port: aPortNum
+	"Binds a SocketStream instance to my 'connection'
+	instance variable and attempts to make the handshake.
+	I will use TLS/SSL for the connection via Zodiac's
+	ZdcSecureSocketStream rather than a regular socket stream."
+	| sock |
+	sock := Socket new.
+	sock connectToHostNamed: aHostname port: aPortNum.
+	connection := IRCSecureSocketStream on: sock.
+	connection connect.
+	self listen.

--- a/Pharo-IRC-Base.package/IRCConnection.class/instance/connectToHostNamed.port..st
+++ b/Pharo-IRC-Base.package/IRCConnection.class/instance/connectToHostNamed.port..st
@@ -2,6 +2,8 @@ initialization
 connectToHostNamed: aHostname port: aPortNum
 	"Binds a SocketStream instance to my 'connection'
 	instance variable and attempts to make the handshake."
-	
-	connection := SocketStream openConnectionToHostNamed: aHostname port: aPortNum.
+	| sock |
+	sock := Socket new.
+	connection := SocketStream on: sock.
+	sock connectToHostNamed: aHostname port: aPortNum.
 	self listen.

--- a/Pharo-IRC-Base.package/IRCConnection.class/instance/handleOutgoing.st
+++ b/Pharo-IRC-Base.package/IRCConnection.class/instance/handleOutgoing.st
@@ -8,7 +8,10 @@ handleOutgoing
 	sentMessages := OrderedCollection new.
 	outQueue do: [ :msg |
 		self connection isConnected ifTrue: [ 
-			self connection sendCommand: msg asString.
+			"self connection sendCommand: msg asString."
+			self connection
+				nextPutAll: ((msg asString), String crlf);
+				flush.
 			sentMessages add: msg.
 			announcer announce: (IRCMessageAnnouncement new message: msg) ] ].
 	

--- a/Pharo-IRC-Base.package/IRCConnection.class/instance/initialHandshake.st
+++ b/Pharo-IRC-Base.package/IRCConnection.class/instance/initialHandshake.st
@@ -2,6 +2,8 @@ initialization
 initialHandshake
 	"Send the initial NICK and USER messages
 	when performing an initial connection to a server."
+	self password ifNotNil: [ 
+		self sendMessage: (IRCProtocolMessage fromString: 'PASS ',(self password)) ].
 	self sendMessage: (IRCProtocolMessage command: 'NICK' arguments: { user nickname }).
 	self sendMessage: (IRCProtocolMessage command: 'USER' arguments: {
 		user username.

--- a/Pharo-IRC-Base.package/IRCConnection.class/instance/password..st
+++ b/Pharo-IRC-Base.package/IRCConnection.class/instance/password..st
@@ -1,0 +1,4 @@
+accessing
+password: aString
+	"Sets the password (if needed) for the underlying user"
+	self user password: aString

--- a/Pharo-IRC-Base.package/IRCConnection.class/instance/password.st
+++ b/Pharo-IRC-Base.package/IRCConnection.class/instance/password.st
@@ -1,0 +1,3 @@
+accessing
+password
+	^ self user password

--- a/Pharo-IRC-Base.package/IRCConnection.class/instance/processNextLine.st
+++ b/Pharo-IRC-Base.package/IRCConnection.class/instance/processNextLine.st
@@ -2,4 +2,6 @@ initialization
 processNextLine
 	"Intermediary method in which we
 	snatch the next line off of the socket"
-	self processNextMessage: (IRCProtocolMessage fromString: connection nextLine).
+	| nextLine |
+	nextLine := connection nextLine.
+	self processNextMessage: (IRCProtocolMessage fromString: nextLine).

--- a/Pharo-IRC-Base.package/IRCSecureSocketStream.class/README.md
+++ b/Pharo-IRC-Base.package/IRCSecureSocketStream.class/README.md
@@ -1,0 +1,1 @@
+I am a subclass of ZdcSecureSocket stream, which is an independent SocketStream implementation that allows TLS/SSL connections. I exist as a subclass because I implement some of the common messages available in SocketStream that are unavailable in ZdcSecureSocketStream.

--- a/Pharo-IRC-Base.package/IRCSecureSocketStream.class/instance/nextLine.st
+++ b/Pharo-IRC-Base.package/IRCSecureSocketStream.class/instance/nextLine.st
@@ -1,0 +1,5 @@
+accessing
+nextLine
+	| wrapper |
+	wrapper := ZnCharacterReadStream on: self.
+	^ wrapper nextLine.

--- a/Pharo-IRC-Base.package/IRCSecureSocketStream.class/instance/timeout.st
+++ b/Pharo-IRC-Base.package/IRCSecureSocketStream.class/instance/timeout.st
@@ -1,0 +1,3 @@
+accessing
+timeout
+	^ Socket standardTimeout

--- a/Pharo-IRC-Base.package/IRCSecureSocketStream.class/properties.json
+++ b/Pharo-IRC-Base.package/IRCSecureSocketStream.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "EricGade 4/25/2018 11:17",
+	"super" : "ZdcSecureSocketStream",
+	"category" : "Pharo-IRC-Base",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "IRCSecureSocketStream",
+	"type" : "normal"
+}

--- a/Pharo-IRC-Base.package/IRCUser.class/instance/password..st
+++ b/Pharo-IRC-Base.package/IRCUser.class/instance/password..st
@@ -1,3 +1,4 @@
 accessing
-password: anObject
-	password := anObject
+password: aString
+	"Set the password for the underlying active user"
+	self user password: aString

--- a/Pharo-IRC-GUI.package/IRCBasicDisplay.class/class/on..st
+++ b/Pharo-IRC-GUI.package/IRCBasicDisplay.class/class/on..st
@@ -1,0 +1,9 @@
+instance creation
+on: anIRCConnection
+	"Open a Basic Display window linked to the
+	passed connection, but don't necessarily start
+	to connect"
+	| model |
+	model := self connection: anIRCConnection.
+	model openWithSpec.
+	model window whenClosedDo: [ model windowCloseAction ].


### PR DESCRIPTION
## What ##
This PR implements two needed features:
1. The ability to connect to an IRC server via TLS/SSL
2. The ability to connect with a password, when set and needed
  
## How ##
### SSL Connections ###
The implementation makes use of `ZdcSecureSocketStream`, but due to the fact that this uses `BinaryStreams` and does not fully implement the common String stream messages (`nextLine`, `upToAll:`, etc), we have to subclass this with `IRCSecureSocketStream` and implement `nextLine` ourselves by wrapping the underlying socket stream with `ZnCharacterReadStream`.
  
It's a bit convoluted, but seems to be the only way to go.

### Authenticating with Password ###
To use a password when connecting, simply set it: `IRCConnection new password: '<somePass>'`.
  
Note that this does not implement any `NickServ` or other functionality. Instead, if a password it set before the connection is made, we send the RFC compliant `PASS` command before the `NICK/USER` handshake.
  
## Using ##
## SSL Connection ##
All funcitonality should be the same, but use `connectSecure` instead of `connect`. Example:
  
```smalltalk
| conn |
conn := IRCConnection new.
conn
    username: 'someUser';
    password: '<pass>';
    nickname: 'someNick';
    port: 7000 "Or some SSL port";
    hostname: 'irc.freenode.net'.
IRCBasicDisplay on: conn.
conn connectSecure.
```
## Authentication / Passwords ##
Simply set the `password:` message before connecting.
  
## Closes ##
#7 